### PR TITLE
Add support for data values on Item costs.

### DIFF
--- a/src/main/java/me/shansen/EggCatcher/listeners/EggCatcherEntityListener.java
+++ b/src/main/java/me/shansen/EggCatcher/listeners/EggCatcherEntityListener.java
@@ -209,9 +209,10 @@ public class EggCatcherEntityListener implements Listener {
 
             if (this.useItemCost) {
                 int itemId = config.getInt("ItemCost.ItemId", 266);
+                int itemData = config.getInt("ItemCost.ItemData", 0);
                 int itemAmount = config.getInt("ItemCost.Amount." + eggType.getFriendlyName(), 0);
-                ItemStack itemStack = new ItemStack(itemId, itemAmount);
-                if (player.getInventory().contains(itemId, itemAmount)) {
+                ItemStack itemStack = new ItemStack(itemId, itemAmount, (short) itemData);
+                if (player.getInventory().containsAtLeast(itemStack, itemStack.getAmount())) {
                     player.sendMessage(String.format(config.getString("Messages.ItemCostSuccess"),
                             String.valueOf(itemAmount)));
                     player.getInventory().removeItem(itemStack);


### PR DESCRIPTION
I wasn't sure exactly how you wanted this handled at the config level so I didn't bother touching it.  The only new config value is completely optional.  If ItemData is specified it's used as the data value of the ItemCost.  This allows for using cocoa beans or ink sacks or another item with a data bit as the ItemCost.
