### PR TITLE
Fixes/requirements before charge

### DIFF
--- a/src/main/java/me/shansen/EggCatcher/listeners/EggCatcherEntityListener.java
+++ b/src/main/java/me/shansen/EggCatcher/listeners/EggCatcherEntityListener.java
@@ -47,7 +47,7 @@ public class EggCatcherEntityListener implements Listener {
     private final boolean usePermissions;
     private final boolean useCatchChance;
     private final boolean useHealthPercentage;
-    private final boolean looseEggOnFail;
+    private final boolean loseEggOnFail;
     private final boolean useVaultCost;
     private final boolean useItemCost;
     private final boolean explosionEffect;
@@ -76,7 +76,7 @@ public class EggCatcherEntityListener implements Listener {
         this.usePermissions = this.config.getBoolean("UsePermissions", true);
         this.useCatchChance = this.config.getBoolean("UseCatchChance", true);
         this.useHealthPercentage = this.config.getBoolean("UseHealthPercentage", false);
-        this.looseEggOnFail = this.config.getBoolean("LooseEggOnFail", true);
+        this.loseEggOnFail = this.config.getBoolean("LooseEggOnFail", true);
         this.useVaultCost = this.config.getBoolean("UseVaultCost", false);
         this.useItemCost = this.config.getBoolean("UseItemCost", false);
         this.explosionEffect = this.config.getBoolean("ExplosionEffect", true);
@@ -125,7 +125,7 @@ public class EggCatcherEntityListener implements Listener {
             if (this.usePermissions) {
                 if (!player.hasPermission("eggcatcher.catch." + eggType.getFriendlyName().toLowerCase())) {
                     player.sendMessage(config.getString("Messages.PermissionFail"));
-                    if (!this.looseEggOnFail) {
+                    if (!this.loseEggOnFail) {
                         player.getInventory().addItem(new ItemStack(Material.EGG, 1));
                         EggCatcher.eggs.add(egg);
                     }
@@ -141,7 +141,7 @@ public class EggCatcherEntityListener implements Listener {
                     if (this.healthPercentageFailMessage.length() > 0) {
                         player.sendMessage(String.format(this.healthPercentageFailMessage, healthPercentage));
                     }
-                    if (!this.looseEggOnFail) {
+                    if (!this.loseEggOnFail) {
                         player.getInventory().addItem(new ItemStack(Material.EGG, 1));
                         EggCatcher.eggs.add(egg);
                     }
@@ -159,7 +159,7 @@ public class EggCatcherEntityListener implements Listener {
                     if (this.catchChanceFailMessage.length() > 0) {
                         player.sendMessage(this.catchChanceFailMessage);
                     }
-                    if (!this.looseEggOnFail) {
+                    if (!this.loseEggOnFail) {
                         player.getInventory().addItem(new ItemStack(Material.EGG, 1));
                         EggCatcher.eggs.add(egg);
                     }
@@ -173,7 +173,7 @@ public class EggCatcherEntityListener implements Listener {
                 double vaultCost = config.getDouble("VaultCost." + eggType.getFriendlyName());
                 if (!EggCatcher.economy.has(player.getName(), vaultCost)) {
                     player.sendMessage(String.format(config.getString("Messages.VaultFail"), vaultCost));
-                    if (!this.looseEggOnFail) {
+                    if (!this.loseEggOnFail) {
                         player.getInventory().addItem(new ItemStack(Material.EGG, 1));
                         EggCatcher.eggs.add(egg);
                     }
@@ -202,7 +202,7 @@ public class EggCatcherEntityListener implements Listener {
                 } else {
                     player.sendMessage(String.format(config.getString("Messages.ItemCostFail"),
                             String.valueOf(itemAmount)));
-                    if (!this.looseEggOnFail) {
+                    if (!this.loseEggOnFail) {
                         player.getInventory().addItem(new ItemStack(Material.EGG, 1));
                         EggCatcher.eggs.add(egg);
                     }


### PR DESCRIPTION
This change fixes an issue where a player would be partially charged for a catch even if they didn't have the rest of the requirements to catch a mob.

For example, when using both vault cost and item cost, the vault cost would be taken away even if the player didn't have the required items. To fix this, I added a requirements check first, then charge any/all requirements once the catch is known to be successful.

Additionally, I encapsulated the egg capture inside an egg capture event listener, rather than triggering the event, checking for cancelled, then proceeding in the same listener.

It's worth noting that on chance fail, the player isn't changed, but that was the case previously as well. I'm not sure if this behavior was intended since that makes it so there really isn't any consequence to failing to capture a mob. I've addressed this separately and can open a different PR where I added a `ChargeOnChanceFail` config option. I wanted to keep these atomic, rather than one large PR. See [features/charge-on-chance-fail](https://github.com/SimpleMC/EggCatcher/commits/features/charge-on-chance-fail).